### PR TITLE
Escaping markdown keywords

### DIFF
--- a/doccano_mini/layout.py
+++ b/doccano_mini/layout.py
@@ -13,6 +13,7 @@ from doccano_mini.components import (
     task_instruction_editor,
     usage,
 )
+from doccano_mini.utils import escape_markdown
 
 
 class BasePage(ABC):
@@ -70,7 +71,7 @@ class BasePage(ABC):
         if st.button("Predict", disabled=llm is None):
             chain = LLMChain(llm=llm, prompt=prompt)  # type:ignore
             response = chain.run(**inputs)
-            st.markdown(response.replace("\n", "  \n"))
+            st.markdown(escape_markdown(response).replace("\n", "  \n"))
 
             chain.save("config.yaml")
             display_download_button()

--- a/doccano_mini/utils.py
+++ b/doccano_mini/utils.py
@@ -1,0 +1,7 @@
+import re
+
+
+def escape_markdown(text: str) -> str:
+    # Brought from https://github.com/python-telegram-bot/python-telegram-bot/blob/v20.2/telegram/helpers.py#L66
+    escape_chars = r"\_*[]()~`>#+-=|{}.!$"
+    return re.sub(f"([{re.escape(escape_chars)}])", r"\\\1", text)


### PR DESCRIPTION
- Before escaping
  - <img width="824" alt="image" src="https://user-images.githubusercontent.com/5953584/228737473-1a917574-3649-4c8c-b06f-30f08119d462.png">

- After escaping
   -  <img width="879" alt="image" src="https://user-images.githubusercontent.com/5953584/228737712-3a52b15c-dc66-4ec8-8a0c-98d262532b19.png">
